### PR TITLE
Fix vertical position of modal when ".reveal-modal" has % "top" property

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -242,7 +242,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
 
         // Create a faux modal div just to measure its
         // distance to top
-        var faux = angular.element('<div class="reveal-modal" style="z-index:-1""></div>');
+        var faux = angular.element('<div class="reveal-modal" style="z-index:-1"></div>');
         parent.append(faux[0]);
         cssTop = parseInt($window.getComputedStyle(faux[0]).top) || 0;
         var openAt = calculateModalTop(faux, cssTop);

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -242,7 +242,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
 
         // Create a faux modal div just to measure its
         // distance to top
-        var faux = angular.element('<div class="reveal-modal" style="z-index:-1"></div>');
+        var faux = angular.element('<div class="reveal-modal" style="z-index:-1; display: block;"></div>');
         parent.append(faux[0]);
         cssTop = parseInt($window.getComputedStyle(faux[0]).top) || 0;
         var openAt = calculateModalTop(faux, cssTop);


### PR DESCRIPTION
Fix vertical position of modal when `.reveal-modal` has % "top" property

(I actually submitted https://github.com/yalabot/angular-foundation/pull/319 too, but I'm not sure if the repository is still being maintained. @cwadrupldijjit Do you plan to maintain this fork? We would love to use it if yes.)

#### Description

Currently, if the "reveal-modal" CSS class is assigned an n% "top" CSS property, the modal would be positioned n px from the top of the viewport.

The modal [uses the following JS](https://github.com/yalabot/angular-foundation/blob/0.8.0/src/modal/modal.js#L247):

```js
window.getComputedStyle(element).top
```

The library inserts an invisible faux modal, computes its top position using above, removes the faux modal, and then inserts the real modal which applies the top position computed earlier.

However, an absolute-positioned element with % "top" property that is hidden through `display: none;` does not evaluate the JS to the same value as when it is visible. The computed "top" value for the hidden element is still the % value, while it is the computed px value if the element is visible or when using `visibility: hidden`. This is demonstrated in [this Plunker](http://next.plnkr.co/plunk/GLdLX84vUpPC7nIG).

`$modalStack.open` [expects the expression above to return the px value](https://github.com/yalabot/angular-foundation/blob/0.8.0/src/modal/modal.js#L247), so a `10%` value gets treated as `10px`. This is not the desired behavior, and a big limitation now that people use a big range of screen sizes.

The faux modal is temporarily inserted with `z-index: -1` (JS), `display: none` (CSS), and `visibility: hidden` (CSS).

As a workaround, this commit applies `display: block` (JS) to the faux modal.

#### Release notes

- Fix vertical position of modal when ".reveal-modal" has % "top" property

Changelog Category: Bug Fixes